### PR TITLE
feat: Enhance Jira integration with issue fetching

### DIFF
--- a/src/apis/JiraApi.ts
+++ b/src/apis/JiraApi.ts
@@ -33,8 +33,10 @@ const DEFAULT_OPTIONS: JiraApiOptions = {
  */
 export default class JiraApi {
   private jiraClient: JiraClient
+  private username: string;
   
   constructor(username: string, apiKey: string, options: Partial<JiraApiOptions> = {}) {
+    this.username = username;
     this.jiraClient = new JiraClient({
       ...DEFAULT_OPTIONS,
       ...options,
@@ -42,6 +44,17 @@ export default class JiraApi {
       password: apiKey,
       apiVersion: "2",
     });
+  }
+
+  /**
+   * Fetures all the issues assigned to the user.
+   * 
+   * @param {boolean} [open=true] Whether to fetch only open issues.
+   * @returns A list of issues assigned to the user.
+   */
+  getUserIssues(open: boolean = true): Promise<JiraIssue[]> {
+    return this.jiraClient.getUsersIssues(this.username, open)
+      .then(issues => issues.map(toJiraIssue));
   }
 
   /**

--- a/src/apis/JiraApi.ts
+++ b/src/apis/JiraApi.ts
@@ -1,6 +1,6 @@
 import JiraClient from "jira-client";
 
-type JiraIssue = {
+export type JiraIssue = {
   key: string;
   summary: string;
   description: string;
@@ -22,6 +22,7 @@ type JiraApiOptions = {
   host: string;
   strictSSL: boolean;
 }
+
 const DEFAULT_OPTIONS: JiraApiOptions = {
   protocol: "https",
   host: "block.atlassian.net",
@@ -53,8 +54,9 @@ export default class JiraApi {
    * @returns A list of issues assigned to the user.
    */
   getUserIssues(open: boolean = true): Promise<JiraIssue[]> {
-    return this.jiraClient.getUsersIssues(this.username, open)
-      .then(issues => issues.map(toJiraIssue));
+    return this.jiraClient
+      .getUsersIssues(this.username, open)
+      .then(response => response.issues?.map(toJiraIssue));
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import prompts from "prompts";
 import { CUSTOM_PROMPT_PATH } from "./generatePrDescription";
 import { config } from "dotenv";
-import JiraApi from "./apis/JiraApi";
+import JiraApi, { JiraIssue } from "./apis/JiraApi";
 
 config(); // Load .env file
 
@@ -53,41 +53,85 @@ export async function extraContextPrompt(): Promise<string> {
   }
 }
 
+async function getJiraPrompts(jiraApi: JiraApi):  Promise<JiraIssue | undefined> {
+  let { command } = await prompts({
+    type: "select",
+    name: "command",
+    message: chalk.yellow("✏️ Do you want to add a Jira ticket description?"),
+    choices: [
+      { title: "Fetch my open tickets", value: "fetch" },
+      { title: "Enter manually", value: "enter" },
+      { title: "No", value: "no" },
+    ],
+  });
+
+  if (command === "fetch") {
+    const issues = await jiraApi.getUserIssues();
+    const issueChoices = issues.map((issue) => ({
+      title: `[${issue.key}] ${issue.summary}`,
+      value: issue,
+    }));
+
+    const { selectedIssue } = await prompts({
+      type: "select",
+      name: "selectedIssue",
+      message: chalk.yellow("Select the Jira ticket to include in the PR description:"),
+      choices: [
+        ...issueChoices,
+        { title: "None", value: "none" },
+        { title: "Enter Manually", value: "enter" },
+      ],
+    });
+
+    if (selectedIssue === "none" || selectedIssue === "enter") {
+      command = selectedIssue;
+    }
+  }
+  
+  if (command === "enter") {
+    const { ticket } = await prompts({
+      type: "text",
+      name: "ticket",
+      message: chalk.cyan("Enter the Jira ticket number:"),
+    });
+
+    return jiraApi.getIssue(ticket);
+  }
+
+  return undefined;
+}
+
+
 export async function getJiraTicketDescription(): Promise<string> {
   const jiraUsername = process.env.SQAUREUP_EMAIL;
   const jiraApiToken = process.env.JIRA_API_TOKEN;
 
   if (!jiraUsername || !jiraApiToken) {
-    console.log(chalk.red("JIra username or API token not found, skipping Jira ticket description."));
+    console.log(chalk.red("Jira username or API token not found, skipping Jira ticket description."));
     return "";
   }
 
   const jira = new JiraApi(jiraUsername, jiraApiToken);
 
-  // prompt user for ticket number
-  const response = await prompts({
-    type: "text",
-    name: "ticketNumber",
-    message: chalk.yellow("Enter the Jira ticket number:"),
-    format: (value) => value.toUpperCase(),
-  });
+  try {
+  const issue = await getJiraPrompts(jira);
 
-  if (response.ticketNumber) {
-    try {
-      const issue = await jira.getIssue(response.ticketNumber);
-      if(issue) {
-        return `\n
-Below are the contents of the Jira ticket, please use it to gain more context on the changes and include a link to the card in the PR description. 
-Also, please include the Jira ticket number ${issue.key} at the start of the PR title in square brackets (eg [${issue.key}]). 
-      
-  \`\`\`
-  ${issue.description}
-  \`\`\``;
-      }
-    } catch (err) {
-      console.error(err);
+    if(issue) {
+      return `
+      Below are the contents of the Jira ticket, please use it to gain more context on the changes and include a link to the card in the PR description.
+      Also, please include the Jira ticket number ${issue.key} at the start of the PR title in square brackets (eg [${issue.key}]).
+
+      \`\`\`
+      ${issue.summary}
+
+      ${issue.description}
+      \`\`\`
+      `;
     }
+  } catch (error) {
+    console.error(chalk.red(`Error fetching Jira ticket: ${error}`));
   }
+
   return "";
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,15 +127,15 @@ export async function getJiraTicketDescription(): Promise<string> {
 
     if(issue) {
       return `
-      Below are the contents of the Jira ticket, please use it to gain more context on the changes and include a link to the card in the PR description.
-      Also, please include the Jira ticket number ${issue.key} at the start of the PR title in square brackets (eg [${issue.key}]).
+Below are the contents of the Jira ticket, please use it to gain more context on the changes and include a link to the card in the PR description.
+Also, please include the Jira ticket number ${issue.key} at the start of the PR title in square brackets (eg [${issue.key}]).
 
-      \`\`\`
-      ${issue.summary}
+\`\`\`
+${issue.summary}
 
-      ${issue.description}
-      \`\`\`
-      `;
+${issue.description}
+\`\`\`
+`;
     }
   } catch (error) {
     console.error(chalk.red(`Error fetching Jira ticket: ${error}`));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ async function getJiraPrompts(jiraApi: JiraApi):  Promise<JiraIssue | undefined>
     }));
 
     const { selectedIssue } = await prompts({
-      type: "select",
+      type: "autocomplete",
       name: "selectedIssue",
       message: chalk.yellow("Select the Jira ticket to include in the PR description:"),
       choices: [
@@ -81,6 +81,15 @@ async function getJiraPrompts(jiraApi: JiraApi):  Promise<JiraIssue | undefined>
         { title: "None", value: "none" },
         { title: "Enter Manually", value: "enter" },
       ],
+      suggest: async (input, choices) => {
+        const lowercaseInput = input.toLowerCase();
+        // Always show the "None" and "Enter Manually" options, all others should be filtered by title.
+        return choices.filter(({ value, title }) => 
+          value === "none" 
+          || value === "enter" 
+          || title.toLowerCase().includes(lowercaseInput)
+        );
+      }
     });
 
     if (selectedIssue === "none" || selectedIssue === "enter") {


### PR DESCRIPTION
## Overview
This feature should significantly ease the process of linking PRs with relevant Jira tickets and ensure PR descriptions are informative and aligned with the changes being introduced.

## What
- Implement a new method `getUserIssues` in the `JiraApi` class, allowing fetching issues assigned to the user with an option to filter only open issues.
- Extend the prompt to allow the user for adding a Jira ticket description to the PR description automatically. This includes fetching open tickets assigned to the user and allowing the user to select a ticket from a list.

### Why
The change is necessary to:
- Streamline the process of including relevant Jira ticket information in PR descriptions, making it easier for developers to provide context on the changes they are introducing.
- Improve developer productivity by reducing the manual effort needed to locate and reference Jira tickets related to the changes being committed.

### Testing
To verify the implementation:

1. Ensure you have valid Jira credentials (username and API token) set up in your environment variables.
2. Try creating a new PR or amending an existing one.
3. Follow the prompt to include a Jira ticket description – it should offer you the options to "Fetch my open tickets", "Enter manually", or "No".
4. If selecting "Fetch my open tickets", you should see a list of open issues assigned to you; you can select one to automatically include its summary and description in your PR description.
5. If any errors occur while fetching Jira tickets (e.g., due to invalid credentials or network issues), you should see a clear error message indicating the problem.
