### PR TITLE
feat: make ChatGPT model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ yarn install
 ```bash
 GITHUB_TOKEN=your_github_token_here        # From https://github.com/settings/tokens (needs 'repo' scope)
 OPENAI_API_KEY=your_openai_api_key_here    # From https://platform.openai.com/api-keys
+OPENAI_MODEL=gpt-4o                        # ChatGPT model to use
 GITHUB_USERNAME=your_github_username_here
 SQUAREUP_EMAIL=your_openai_email_here
 JIRA_API_TOKEN=your_jira_api_token_here

--- a/call-chatgpt.sh
+++ b/call-chatgpt.sh
@@ -12,6 +12,8 @@ if [ -z "$OPENAI_API_KEY" ]; then
   exit 1
 fi
 
+MODEL="${OPENAI_MODEL:-gpt-4o}"
+
 PROMPT=$(cat "${PROMPT_FILE}")
 
 # Define your detailed prompt as a variable
@@ -40,7 +42,8 @@ Jan 25, 2024:
 json_payload=$(jq -n \
     --arg prompt "$PROMPT" \
     --arg detailed_prompt "$detailed_prompt" \
-    '{ "model": "gpt-4-0125-preview", "messages": [{ "role": "user", "content": ($detailed_prompt + "\n" + $prompt) }] }')
+    --arg model "$MODEL" \
+    '{ "model": $model, "messages": [{ "role": "user", "content": ($detailed_prompt + "\n" + $prompt) }] }')
 
 # Send the payload to the OpenAI API
 response=$(curl -s -X POST "https://api.openai.com/v1/chat/completions" \

--- a/script/setup
+++ b/script/setup
@@ -91,6 +91,7 @@ echo -e "${YELLOW}The .env file should look exactly like this (with your custom 
 
 echo -e "${BLUE}GITHUB_TOKEN=<your_github_token_here>${NC}"
 echo -e "${BLUE}OPENAI_API_KEY=<your_openai_api_key_here>${NC}"
+echo -e "${BLUE}OPENAI_MODEL=<your_preferred_openai_model>${NC}"
 echo -e "${BLUE}GITHUB_USERNAME=<your_github_username_here>${NC}"
 echo -e "${BLUE}SQUAREUP_EMAIL=<your_squareup_email>${NC}"
 echo -e "${BLUE}JIRA_API_TOKEN=<generated_jira_api_token>${NC}"

--- a/src/ChatGPTApi.ts
+++ b/src/ChatGPTApi.ts
@@ -5,10 +5,11 @@ export async function callChatGPTApi(
   userContent: string,
 ): Promise<string> {
   try {
+    const model = process.env.OPENAI_MODEL ?? "gpt-4o";
     const response = await axios.post(
       "https://api.openai.com/v1/chat/completions",
       {
-        model: "gpt-4o",
+        model,
         messages: [
           {
             role: "system",

--- a/src/__tests__/ChatGPTApi.test.ts
+++ b/src/__tests__/ChatGPTApi.test.ts
@@ -7,14 +7,17 @@ describe("ChatGPTApi", () => {
   const mockSystemContent = "system content";
   const mockUserContent = "user content";
   const mockApiKey = "test-api-key";
+  const mockModel = "test-model";
 
   beforeEach(() => {
     process.env.OPENAI_API_KEY = mockApiKey;
+    process.env.OPENAI_MODEL = mockModel;
     jest.clearAllMocks();
   });
 
   afterEach(() => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_MODEL;
   });
 
   it("should call OpenAI API with correct parameters", async () => {
@@ -37,7 +40,7 @@ describe("ChatGPTApi", () => {
     expect(axios.post).toHaveBeenCalledWith(
       "https://api.openai.com/v1/chat/completions",
       {
-        model: "gpt-4o",
+        model: mockModel,
         messages: [
           {
             role: "system",


### PR DESCRIPTION
## Summary
- allow specifying ChatGPT model via `OPENAI_MODEL` env var
- update tests, documentation, and scripts for new model configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae658233cc8333a6bb013b96ee5261